### PR TITLE
Remove unused slugify library (not Python 3 compatible)

### DIFF
--- a/bin/anpy-cli
+++ b/bin/anpy-cli
@@ -6,13 +6,12 @@ import sys
 import os
 import bs4
 import datetime
-from urllib.parse import urljoin, urlparse
+from urllib.parse import urljoin
 
 from pathlib import Path
 
 import attr
 import click
-import slugify
 
 from anpy.dossier import Dossier
 from anpy.dossier_like_senapy import parse as parse_dossier_like_senapy
@@ -37,12 +36,6 @@ def is_valid_dosleg_resp(resp):
     else:
         print('[INVALID STATUS CODE]', resp.status_code, resp.url)
     return False
-
-
-def dossier_id(url):
-    scheme, netloc, path, params, query, fragment = urlparse(url)
-    return slugify.slugify(path.replace('dossiers/', '') \
-        .replace('.asp', ''))
 
 
 def _log(*args):

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,5 @@ mistune < 0.9, >= 0.8
 dateparser < 0.8, >= 0.7
 attrs < 17.5, >= 17.4
 future < 0.17, >= 0.16
-slugify < 0.1, >= 0.0
 
 lawfactory_utils


### PR DESCRIPTION
Removing dead code, as that library was only used in a no-longer used function.