### PR TITLE
RINF translates to rap-inf

### DIFF
--- a/anpy/dossier_from_opendata.py
+++ b/anpy/dossier_from_opendata.py
@@ -291,8 +291,8 @@ def an_text_url(identifiant, code):
             'suffixe': '',
         },
         'RINF': {
-            'repertoire': 'rapports',
-            'prefixe': 'r',
+            'repertoire': 'rap-inf',
+            'prefixe': 'i',
             'suffixe': '',
         }
     }


### PR DESCRIPTION
In this [RINFANR5L15B1241](https://git.en-root.org/tricoteuses/data/assemblee-nettoye/Dossiers_Legislatifs_XV_nettoye/blob/ec160f7d701a6ec27286d84498ed75ebd2f6517f/documents/RINF/AN/R5/15/B/001/RINFANR5L15B1241.json#L3) RINF translates into [rap-inf](http://www.assemblee-nationale.fr/15/rap-info/i1241.asp) with prefix **i**.