### PR TITLE
opendata: TAP (Texte Adopté Provisoire) maps exactly as BTA

### DIFF
--- a/anpy/dossier_from_opendata.py
+++ b/anpy/dossier_from_opendata.py
@@ -304,6 +304,8 @@ def an_text_url(identifiant, code):
         type = 'TCOM'
     elif typeTa == 'BTA':
         type = 'TADO'
+    elif typeTa == 'TAP':
+        type = 'TADO'
     else:
         type = code
     host = "http://www.assemblee-nationale.fr/"


### PR DESCRIPTION
A "dossier législatif" may reference[0] a document similar to
PRJLANR5L15TAP0066[1], i.e. with TAP (Texte Adopté Provisoire). It
maps to the same URL as BTA (Bibard Texte Adopté).

[0] https://git.en-root.org/tricoteuses/data/assemblee-nettoye/Dossiers_Legislatifs_XV_nettoye/blob/5ece97db03ab1e0daa931ef913d4777b0f3a6ffc/dossiers/R5/L15/035/DLR5L15N35984.json#L1012
[1] http://www.assemblee-nationale.fr/14/ta/ta0066.asp